### PR TITLE
Add run_tags configuration to builder

### DIFF
--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -147,6 +147,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			UserData:                    b.config.UserData,
 			UserDataFile:                b.config.UserDataFile,
 			RamRoleName:                 b.config.RamRoleName,
+			Tags:                        b.config.RunTags,
 			RegionId:                    b.config.AlicloudRegion,
 			InternetChargeType:          b.config.InternetChargeType,
 			InternetMaxBandwidthOut:     b.config.InternetMaxBandwidthOut,

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -91,6 +91,7 @@ type FlatConfig struct {
 	ForceStopInstance                 *bool                    `mapstructure:"force_stop_instance" required:"false" cty:"force_stop_instance" hcl:"force_stop_instance"`
 	DisableStopInstance               *bool                    `mapstructure:"disable_stop_instance" required:"false" cty:"disable_stop_instance" hcl:"disable_stop_instance"`
 	RamRoleName                       *string                  `mapstructure:"ram_role_name" required:"false" cty:"ram_role_name" hcl:"ram_role_name"`
+	RunTags                           map[string]string        `mapstructure:"run_tags" required:"false" cty:"run_tags" hcl:"run_tags"`
 	SecurityGroupId                   *string                  `mapstructure:"security_group_id" required:"false" cty:"security_group_id" hcl:"security_group_id"`
 	SecurityGroupName                 *string                  `mapstructure:"security_group_name" required:"false" cty:"security_group_name" hcl:"security_group_name"`
 	SecurityEnhancementStrategy       *string                  `mapstructure:"security_enhancement_strategy" required:"false" cty:"security_enhancement_strategy" hcl:"security_enhancement_strategy"`
@@ -212,6 +213,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"force_stop_instance":           &hcldec.AttrSpec{Name: "force_stop_instance", Type: cty.Bool, Required: false},
 		"disable_stop_instance":         &hcldec.AttrSpec{Name: "disable_stop_instance", Type: cty.Bool, Required: false},
 		"ram_role_name":                 &hcldec.AttrSpec{Name: "ram_role_name", Type: cty.String, Required: false},
+		"run_tags":                      &hcldec.AttrSpec{Name: "run_tags", Type: cty.Map(cty.String), Required: false},
 		"security_group_id":             &hcldec.AttrSpec{Name: "security_group_id", Type: cty.String, Required: false},
 		"security_group_name":           &hcldec.AttrSpec{Name: "security_group_name", Type: cty.String, Required: false},
 		"security_enhancement_strategy": &hcldec.AttrSpec{Name: "security_enhancement_strategy", Type: cty.String, Required: false},

--- a/builder/ecs/run_config.go
+++ b/builder/ecs/run_config.go
@@ -52,6 +52,9 @@ type RunConfig struct {
 	DisableStopInstance bool `mapstructure:"disable_stop_instance" required:"false"`
 	// Ram Role to apply when launching the instance.
 	RamRoleName string `mapstructure:"ram_role_name" required:"false"`
+	// Key/value pair tags to apply to the instance that is *launched*
+	// to create the image.
+	RunTags map[string]string `mapstructure:"run_tags" required:"false"`
 	// ID of the security group to which a newly
 	// created instance belongs. Mutual access is allowed between instances in one
 	// security group. If not specified, the newly created instance will be added
@@ -135,6 +138,10 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		c.Comm.SSHPrivateKeyFile == "" && c.Comm.SSHPassword == "" && c.Comm.WinRMPassword == "" {
 
 		c.Comm.SSHTemporaryKeyPairName = fmt.Sprintf("packer_%s", uuid.TimeOrderedUUID())
+	}
+
+	if c.RunTags == nil {
+		c.RunTags = make(map[string]string)
 	}
 
 	// Validation

--- a/builder/ecs/step_create_instance.go
+++ b/builder/ecs/step_create_instance.go
@@ -23,6 +23,7 @@ type stepCreateAlicloudInstance struct {
 	UserData                    string
 	UserDataFile                string
 	RamRoleName                 string
+	Tags                        map[string]string
 	RegionId                    string
 	InternetChargeType          string
 	InternetMaxBandwidthOut     int
@@ -118,6 +119,7 @@ func (s *stepCreateAlicloudInstance) buildCreateInstanceRequest(state multistep.
 	request.InstanceType = s.InstanceType
 	request.InstanceName = s.InstanceName
 	request.RamRoleName = s.RamRoleName
+	request.Tag = buildCreateInstanceTags(s.Tags)
 	request.ZoneId = s.ZoneId
 	request.SecurityEnhancementStrategy = s.SecurityEnhancementStrategy
 	if s.AlicloudImageFamily != "" {
@@ -211,4 +213,14 @@ func (s *stepCreateAlicloudInstance) getUserData(state multistep.StateBag) (stri
 
 	return userData, nil
 
+}
+
+func buildCreateInstanceTags(tags map[string]string) *[]ecs.CreateInstanceTag {
+	var ecsTags []ecs.CreateInstanceTag
+
+	for k, v := range tags {
+		ecsTags = append(ecsTags, ecs.CreateInstanceTag{Key: k, Value: v})
+	}
+
+	return &ecsTags
 }

--- a/docs-partials/builder/ecs/RunConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/RunConfig-not-required.mdx
@@ -26,6 +26,9 @@
 
 - `ram_role_name` (string) - Ram Role to apply when launching the instance.
 
+- `run_tags` (map[string]string) - Key/value pair tags to apply to the instance that is *launched*
+  to create the image.
+
 - `security_group_id` (string) - ID of the security group to which a newly
   created instance belongs. Mutual access is allowed between instances in one
   security group. If not specified, the newly created instance will be added

--- a/docs/builders/alicloud-ecs.mdx
+++ b/docs/builders/alicloud-ecs.mdx
@@ -77,6 +77,10 @@ Here is a basic example for Alicloud.
       "io_optimized": "true",
       "internet_charge_type": "PayByTraffic",
       "image_force_delete": "true"
+      "run_tags": {
+        "Managed by": "Packer",
+        "Built by": "Packer"
+      }
     }
   ],
   "provisioners": [
@@ -111,6 +115,10 @@ source "alicloud-ecs" "basic-example" {
       io_optimized = true
       internet_charge_type = "PayByTraffic"
       image_force_delete = true
+      run_tags  = {
+        "Built by"   = "Packer"
+        "Managed by" = "Packer"
+      }
 }
 
 build {

--- a/post-processor/alicloud-import/post-processor.hcl2spec.go
+++ b/post-processor/alicloud-import/post-processor.hcl2spec.go
@@ -55,6 +55,7 @@ type FlatConfig struct {
 	ForceStopInstance                 *bool                        `mapstructure:"force_stop_instance" required:"false" cty:"force_stop_instance" hcl:"force_stop_instance"`
 	DisableStopInstance               *bool                        `mapstructure:"disable_stop_instance" required:"false" cty:"disable_stop_instance" hcl:"disable_stop_instance"`
 	RamRoleName                       *string                      `mapstructure:"ram_role_name" required:"false" cty:"ram_role_name" hcl:"ram_role_name"`
+	RunTags                           map[string]string            `mapstructure:"run_tags" required:"false" cty:"run_tags" hcl:"run_tags"`
 	SecurityGroupId                   *string                      `mapstructure:"security_group_id" required:"false" cty:"security_group_id" hcl:"security_group_id"`
 	SecurityGroupName                 *string                      `mapstructure:"security_group_name" required:"false" cty:"security_group_name" hcl:"security_group_name"`
 	SecurityEnhancementStrategy       *string                      `mapstructure:"security_enhancement_strategy" required:"false" cty:"security_enhancement_strategy" hcl:"security_enhancement_strategy"`
@@ -184,6 +185,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"force_stop_instance":           &hcldec.AttrSpec{Name: "force_stop_instance", Type: cty.Bool, Required: false},
 		"disable_stop_instance":         &hcldec.AttrSpec{Name: "disable_stop_instance", Type: cty.Bool, Required: false},
 		"ram_role_name":                 &hcldec.AttrSpec{Name: "ram_role_name", Type: cty.String, Required: false},
+		"run_tags":                      &hcldec.AttrSpec{Name: "run_tags", Type: cty.Map(cty.String), Required: false},
 		"security_group_id":             &hcldec.AttrSpec{Name: "security_group_id", Type: cty.String, Required: false},
 		"security_group_name":           &hcldec.AttrSpec{Name: "security_group_name", Type: cty.String, Required: false},
 		"security_enhancement_strategy": &hcldec.AttrSpec{Name: "security_enhancement_strategy", Type: cty.String, Required: false},


### PR DESCRIPTION
`run_tags` (map[string]string) - Key/value pair tags to apply to the instance that is launched to create the image.

I have tested the change locally, and it works as expected.

Closes #20 
