### PR TITLE
.github: stop ignoring dependabot commits on release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,8 +2,6 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
-    authors:
-      - dependabot
   categories:
     - title: Breaking Changes 🛠
       labels:


### PR DESCRIPTION
The current settings for the release prevent dependabot commits from appearing in the release notes when a new version of the plugin is released.

This hides some potentially relevant changes to include in the release notes, therefore we introduce them.