### PR TITLE
 feat: Add ResourceGroupId Parameter

### DIFF
--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -69,6 +69,7 @@ type FlatConfig struct {
 	AlicloudImageName                 *string                  `mapstructure:"image_name" required:"true" cty:"image_name" hcl:"image_name"`
 	AlicloudImageVersion              *string                  `mapstructure:"image_version" required:"false" cty:"image_version" hcl:"image_version"`
 	AlicloudImageDescription          *string                  `mapstructure:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
+	AlicloudResourceGroupId           *string                  `mapstructure:"resource_group_id" required:"false" cty:"resource_group_id" hcl:"resource_group_id"`
 	AlicloudImageShareAccounts        []string                 `mapstructure:"image_share_account" required:"false" cty:"image_share_account" hcl:"image_share_account"`
 	AlicloudImageUNShareAccounts      []string                 `mapstructure:"image_unshare_account" cty:"image_unshare_account" hcl:"image_unshare_account"`
 	AlicloudImageDestinationRegions   []string                 `mapstructure:"image_copy_regions" required:"false" cty:"image_copy_regions" hcl:"image_copy_regions"`
@@ -192,6 +193,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_name":                       &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"image_version":                    &hcldec.AttrSpec{Name: "image_version", Type: cty.String, Required: false},
 		"image_description":                &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
+		"resource_group_id":                &hcldec.AttrSpec{Name: "resource_group_id", Type: cty.String, Required: false},
 		"image_share_account":              &hcldec.AttrSpec{Name: "image_share_account", Type: cty.List(cty.String), Required: false},
 		"image_unshare_account":            &hcldec.AttrSpec{Name: "image_unshare_account", Type: cty.List(cty.String), Required: false},
 		"image_copy_regions":               &hcldec.AttrSpec{Name: "image_copy_regions", Type: cty.List(cty.String), Required: false},

--- a/builder/ecs/image_config.go
+++ b/builder/ecs/image_config.go
@@ -108,6 +108,9 @@ type AlicloudImageConfig struct {
 	// characters. Leaving it blank means null, which is the default value. It
 	// cannot begin with `http://` or `https://`.
 	AlicloudImageDescription string `mapstructure:"image_description" required:"false"`
+	// The ID of the resource group to which to assign the custom image.
+	// If you do not specify this parameter, the image is assigned to the default resource group.
+	AlicloudResourceGroupId string `mapstructure:"resource_group_id" required:"false"`
 	// The IDs of to-be-added Aliyun accounts to which the image is shared. The
 	// number of accounts is 1 to 10. If number of accounts is greater than 10,
 	// this parameter is ignored.

--- a/builder/ecs/step_create_image.go
+++ b/builder/ecs/step_create_image.go
@@ -131,6 +131,7 @@ func (s *stepCreateAlicloudImage) buildCreateImageRequest(state multistep.StateB
 	request.ImageName = imageName
 	request.ImageVersion = config.AlicloudImageVersion
 	request.Description = config.AlicloudImageDescription
+	request.ResourceGroupId = config.AlicloudResourceGroupId
 
 	if s.AlicloudImageIgnoreDataDisks {
 		snapshotId := state.Get("alicloudsnapshot").(string)

--- a/builder/ecs/step_region_copy_image.go
+++ b/builder/ecs/step_region_copy_image.go
@@ -54,6 +54,7 @@ func (s *stepRegionCopyAlicloudImage) Run(ctx context.Context, state multistep.S
 		copyImageRequest.ImageId = srcImageId
 		copyImageRequest.DestinationRegionId = destinationRegion
 		copyImageRequest.DestinationImageName = ecsImageName
+		copyImageRequest.ResourceGroupId = config.AlicloudResourceGroupId
 		if config.ImageEncrypted != confighelper.TriUnset {
 			copyImageRequest.Encrypted = requests.NewBoolean(config.ImageEncrypted.True())
 		}

--- a/docs-partials/builder/ecs/AlicloudImageConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/AlicloudImageConfig-not-required.mdx
@@ -7,6 +7,9 @@
   characters. Leaving it blank means null, which is the default value. It
   cannot begin with `http://` or `https://`.
 
+- `resource_group_id` (string) - The ID of the resource group to which to assign the custom image.
+  If you do not specify this parameter, the image is assigned to the default resource group.
+
 - `image_share_account` ([]string) - The IDs of to-be-added Aliyun accounts to which the image is shared. The
   number of accounts is 1 to 10. If number of accounts is greater than 10,
   this parameter is ignored.

--- a/docs-partials/post-processor/alicloud-import/Config-not-required.mdx
+++ b/docs-partials/post-processor/alicloud-import/Config-not-required.mdx
@@ -17,6 +17,8 @@
   characters. Leaving it blank means null, which is the default value. It
   cannot begin with `http://` or `https://`.
 
+- `resource_group_id` (string) - Alicloud Resource Group Id
+
 - `image_share_account` ([]string) - Alicloud Image Share Accounts
 
 - `image_copy_regions` ([]string) - Alicloud Image Destination Regions

--- a/post-processor/alicloud-import/post-processor.go
+++ b/post-processor/alicloud-import/post-processor.go
@@ -78,6 +78,7 @@ type Config struct {
 	// characters. Leaving it blank means null, which is the default value. It
 	// cannot begin with `http://` or `https://`.
 	AlicloudImageDescription        string   `mapstructure:"image_description"`
+	AlicloudResourceGroupId         string   `mapstructure:"resource_group_id"`
 	AlicloudImageShareAccounts      []string `mapstructure:"image_share_account"`
 	AlicloudImageDestinationRegions []string `mapstructure:"image_copy_regions"`
 	// Type of the OS, like linux/windows
@@ -467,7 +468,7 @@ func (p *PostProcessor) buildImportImageRequest() *ecs.ImportImageRequest {
 			OSSObject:     p.config.OSSKey,
 		},
 	}
-
+	request.ResourceGroupId = p.config.AlicloudResourceGroupId
 	return request
 }
 

--- a/post-processor/alicloud-import/post-processor.hcl2spec.go
+++ b/post-processor/alicloud-import/post-processor.hcl2spec.go
@@ -33,6 +33,7 @@ type FlatConfig struct {
 	AlicloudImageName                 *string                      `mapstructure:"image_name" required:"true" cty:"image_name" hcl:"image_name"`
 	AlicloudImageVersion              *string                      `mapstructure:"image_version" required:"false" cty:"image_version" hcl:"image_version"`
 	AlicloudImageDescription          *string                      `mapstructure:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
+	AlicloudResourceGroupId           *string                      `mapstructure:"resource_group_id" required:"false" cty:"resource_group_id" hcl:"resource_group_id"`
 	AlicloudImageShareAccounts        []string                     `mapstructure:"image_share_account" required:"false" cty:"image_share_account" hcl:"image_share_account"`
 	AlicloudImageUNShareAccounts      []string                     `mapstructure:"image_unshare_account" cty:"image_unshare_account" hcl:"image_unshare_account"`
 	AlicloudImageDestinationRegions   []string                     `mapstructure:"image_copy_regions" required:"false" cty:"image_copy_regions" hcl:"image_copy_regions"`
@@ -164,6 +165,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_name":                       &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"image_version":                    &hcldec.AttrSpec{Name: "image_version", Type: cty.String, Required: false},
 		"image_description":                &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
+		"resource_group_id":                &hcldec.AttrSpec{Name: "resource_group_id", Type: cty.String, Required: false},
 		"image_share_account":              &hcldec.AttrSpec{Name: "image_share_account", Type: cty.List(cty.String), Required: false},
 		"image_unshare_account":            &hcldec.AttrSpec{Name: "image_unshare_account", Type: cty.List(cty.String), Required: false},
 		"image_copy_regions":               &hcldec.AttrSpec{Name: "image_copy_regions", Type: cty.List(cty.String), Required: false},


### PR DESCRIPTION
This MR add ResourceGroupId parameter for three APIs:

- CreateImage
- ImportImage
- CopyImage

The specified parameter add capability to specify resource group for images. If you do not specify this parameter, the image is assigned to the default resource group.

Closes #59 

