### PR TITLE
Add `ram_role_arn` and `ram_session_name` arguments to allow authentication with RamRoleArn mode

### DIFF
--- a/builder/ecs/access_config.go
+++ b/builder/ecs/access_config.go
@@ -30,6 +30,10 @@ type AlicloudAccessConfig struct {
 	AlicloudRegion string `mapstructure:"region" required:"true"`
 	// Alicloud RamRole must be provided for EcsRamRole mode unless `profile` is set.
 	AlicloudRamRole string `mapstructure:"ram_role_name" required:"true"`
+	// Alicloud RamRoleArn must be provided for RamRoleArn mode unless `profile` is set.
+	AlicloudRamRoleArn string `mapstructure:"ram_role_arn" required:"true"`
+	// Alicloud RamRoleArn must be provided for RamRoleArn mode unless `profile` is set.
+	AlicloudRamSessionName string `mapstructure:"ram_session_name" required:"true"`
 	// The region validation can be skipped if this value is true, the default
 	// value is false.
 	AlicloudSkipValidation bool `mapstructure:"skip_region_validation" required:"false"`
@@ -82,17 +86,27 @@ func (c *AlicloudAccessConfig) Client() (*ClientWrapper, error) {
 		_ = endpoints.AddEndpointMapping(c.AlicloudRegion, "Ecs", c.CustomEndpointEcs)
 	}
 
-	if c.AlicloudRamRole == "" {
-		c.AlicloudRamRole = getProviderConfig(c.AlicloudRamRole, "ram_role_name")
-	}
-	if c.AlicloudRamRole != "" {
-		client, err = ecs.NewClientWithEcsRamRole(c.AlicloudRegion, c.AlicloudRamRole)
+	c.AlicloudRamRoleArn = getProviderConfig(c.AlicloudRamRole, "ram_role_arn")
+	c.AlicloudRamSessionName = getProviderConfig(c.AlicloudRamSessionName, "ram_session_name")
+
+	if c.AlicloudRamRoleArn != "" && c.AlicloudRamSessionName != "" {
+		client, err = ecs.NewClientWithRamRoleArn(
+			c.AlicloudRegion, c.AlicloudAccessKey,
+			c.AlicloudSecretKey, c.AlicloudRamRoleArn, c.AlicloudRamSessionName)
 	} else {
-		if c.AlicloudAccessKey == "" || c.AlicloudSecretKey == "" {
-			c.AlicloudAccessKey = getProviderConfig(c.AlicloudAccessKey, "access_key_id")
-			c.AlicloudSecretKey = getProviderConfig(c.AlicloudSecretKey, "access_key_secret")
+		if c.AlicloudRamRole == "" {
+			c.AlicloudRamRole = getProviderConfig(c.AlicloudRamRole, "ram_role_name")
 		}
-		client, err = ecs.NewClientWithStsToken(c.AlicloudRegion, c.AlicloudAccessKey, c.AlicloudSecretKey, c.SecurityToken)
+
+		if c.AlicloudRamRole != "" {
+			client, err = ecs.NewClientWithEcsRamRole(c.AlicloudRegion, c.AlicloudRamRole)
+		} else {
+			if c.AlicloudAccessKey == "" || c.AlicloudSecretKey == "" {
+				c.AlicloudAccessKey = getProviderConfig(c.AlicloudAccessKey, "access_key_id")
+				c.AlicloudSecretKey = getProviderConfig(c.AlicloudSecretKey, "access_key_secret")
+			}
+			client, err = ecs.NewClientWithStsToken(c.AlicloudRegion, c.AlicloudAccessKey, c.AlicloudSecretKey, c.SecurityToken)
+		}
 	}
 
 	if err != nil {

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -60,6 +60,8 @@ type FlatConfig struct {
 	AlicloudSecretKey                 *string                  `mapstructure:"secret_key" required:"true" cty:"secret_key" hcl:"secret_key"`
 	AlicloudRegion                    *string                  `mapstructure:"region" required:"true" cty:"region" hcl:"region"`
 	AlicloudRamRole                   *string                  `mapstructure:"ram_role_name" required:"true" cty:"ram_role_name" hcl:"ram_role_name"`
+	AlicloudRamRoleArn                *string                  `mapstructure:"ram_role_arn" required:"true" cty:"ram_role_arn" hcl:"ram_role_arn"`
+	AlicloudRamSessionName            *string                  `mapstructure:"ram_session_name" required:"true" cty:"ram_session_name" hcl:"ram_session_name"`
 	AlicloudSkipValidation            *bool                    `mapstructure:"skip_region_validation" required:"false" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	AlicloudSkipImageValidation       *bool                    `mapstructure:"skip_image_validation" required:"false" cty:"skip_image_validation" hcl:"skip_image_validation"`
 	AlicloudProfile                   *string                  `mapstructure:"profile" required:"false" cty:"profile" hcl:"profile"`
@@ -184,6 +186,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"secret_key":                       &hcldec.AttrSpec{Name: "secret_key", Type: cty.String, Required: false},
 		"region":                           &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"ram_role_name":                    &hcldec.AttrSpec{Name: "ram_role_name", Type: cty.String, Required: false},
+		"ram_role_arn":                     &hcldec.AttrSpec{Name: "ram_role_arn", Type: cty.String, Required: false},
+		"ram_session_name":                 &hcldec.AttrSpec{Name: "ram_session_name", Type: cty.String, Required: false},
 		"skip_region_validation":           &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"skip_image_validation":            &hcldec.AttrSpec{Name: "skip_image_validation", Type: cty.Bool, Required: false},
 		"profile":                          &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},

--- a/docs-partials/builder/ecs/AlicloudAccessConfig-required.mdx
+++ b/docs-partials/builder/ecs/AlicloudAccessConfig-required.mdx
@@ -11,4 +11,8 @@
 
 - `ram_role_name` (string) - Alicloud RamRole must be provided for EcsRamRole mode unless `profile` is set.
 
+- `ram_role_arn` (string) - Alicloud RamRoleArn must be provided for RamRoleArn mode unless `profile` is set.
+
+- `ram_session_name` (string) - Alicloud RamRoleArn must be provided for RamRoleArn mode unless `profile` is set.
+
 <!-- End of code generated from the comments of the AlicloudAccessConfig struct in builder/ecs/access_config.go; -->

--- a/post-processor/alicloud-import/post-processor.hcl2spec.go
+++ b/post-processor/alicloud-import/post-processor.hcl2spec.go
@@ -24,6 +24,8 @@ type FlatConfig struct {
 	AlicloudSecretKey                 *string                      `mapstructure:"secret_key" required:"true" cty:"secret_key" hcl:"secret_key"`
 	AlicloudRegion                    *string                      `mapstructure:"region" required:"true" cty:"region" hcl:"region"`
 	AlicloudRamRole                   *string                      `mapstructure:"ram_role_name" required:"true" cty:"ram_role_name" hcl:"ram_role_name"`
+	AlicloudRamRoleArn                *string                      `mapstructure:"ram_role_arn" required:"true" cty:"ram_role_arn" hcl:"ram_role_arn"`
+	AlicloudRamSessionName            *string                      `mapstructure:"ram_session_name" required:"true" cty:"ram_session_name" hcl:"ram_session_name"`
 	AlicloudSkipValidation            *bool                        `mapstructure:"skip_region_validation" required:"false" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	AlicloudSkipImageValidation       *bool                        `mapstructure:"skip_image_validation" required:"false" cty:"skip_image_validation" hcl:"skip_image_validation"`
 	AlicloudProfile                   *string                      `mapstructure:"profile" required:"false" cty:"profile" hcl:"profile"`
@@ -156,6 +158,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"secret_key":                       &hcldec.AttrSpec{Name: "secret_key", Type: cty.String, Required: false},
 		"region":                           &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"ram_role_name":                    &hcldec.AttrSpec{Name: "ram_role_name", Type: cty.String, Required: false},
+		"ram_role_arn":                     &hcldec.AttrSpec{Name: "ram_role_arn", Type: cty.String, Required: false},
+		"ram_session_name":                 &hcldec.AttrSpec{Name: "ram_session_name", Type: cty.String, Required: false},
 		"skip_region_validation":           &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"skip_image_validation":            &hcldec.AttrSpec{Name: "skip_image_validation", Type: cty.Bool, Required: false},
 		"profile":                          &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},


### PR DESCRIPTION
Authenticate with Alibaba Cloud RAM with RAM Role Arn mode if necessary. See `role ARN` on https://www.alibabacloud.com/help/en/resource-access-management/latest/ram-role-overview

Closes #78 

