### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/builder/ecs/image_config.go
+++ b/builder/ecs/image_config.go
@@ -135,12 +135,12 @@ type AlicloudImageConfig struct {
 	// images and then create the target images, otherwise, the creation will
 	// fail. The default value is false. Check `image_name` and
 	// `image_copy_names` options for names of target images. If
-	// [-force](/docs/commands/build#force) option is provided in `build`
+	// [-force](/packer/docs/commands/build#force) option is provided in `build`
 	// command, this option can be omitted and taken as true.
 	AlicloudImageForceDelete bool `mapstructure:"image_force_delete" required:"false"`
 	// If this value is true, when delete the duplicated existing images, the
 	// source snapshots of those images will be delete either. If
-	// [-force](/docs/commands/build#force) option is provided in `build`
+	// [-force](/packer/docs/commands/build#force) option is provided in `build`
 	// command, this option can be omitted and taken as true.
 	AlicloudImageForceDeleteSnapshots bool `mapstructure:"image_force_delete_snapshots" required:"false"`
 	AlicloudImageForceDeleteInstances bool `mapstructure:"image_force_delete_instances"`
@@ -157,7 +157,7 @@ type AlicloudImageConfig struct {
 	AlicloudImageTags map[string]string `mapstructure:"tags" required:"false"`
 	// Same as [`tags`](#tags) but defined as a singular repeatable block
 	// containing a `key` and a `value` field. In HCL2 mode the
-	// [`dynamic_block`](/docs/templates/hcl_templates/expressions#dynamic-blocks)
+	// [`dynamic_block`](/packer/docs/templates/hcl_templates/expressions#dynamic-blocks)
 	// will allow you to create those programatically.
 	AlicloudImageTag    config.KeyValues `mapstructure:"tag" required:"false"`
 	AlicloudDiskDevices `mapstructure:",squash"`

--- a/docs-partials/builder/ecs/AlicloudImageConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/AlicloudImageConfig-not-required.mdx
@@ -35,12 +35,12 @@
   images and then create the target images, otherwise, the creation will
   fail. The default value is false. Check `image_name` and
   `image_copy_names` options for names of target images. If
-  [-force](/docs/commands/build#force) option is provided in `build`
+  [-force](/packer/docs/commands/build#force) option is provided in `build`
   command, this option can be omitted and taken as true.
 
 - `image_force_delete_snapshots` (bool) - If this value is true, when delete the duplicated existing images, the
   source snapshots of those images will be delete either. If
-  [-force](/docs/commands/build#force) option is provided in `build`
+  [-force](/packer/docs/commands/build#force) option is provided in `build`
   command, this option can be omitted and taken as true.
 
 - `image_force_delete_instances` (bool) - Alicloud Image Force Delete Instances
@@ -58,7 +58,7 @@
 
 - `tag` ([]{key string, value string}) - Same as [`tags`](#tags) but defined as a singular repeatable block
   containing a `key` and a `value` field. In HCL2 mode the
-  [`dynamic_block`](/docs/templates/hcl_templates/expressions#dynamic-blocks)
+  [`dynamic_block`](/packer/docs/templates/hcl_templates/expressions#dynamic-blocks)
   will allow you to create those programatically.
 
 <!-- End of code generated from the comments of the AlicloudImageConfig struct in builder/ecs/image_config.go; -->

--- a/docs-partials/post-processor/alicloud-import/Config-not-required.mdx
+++ b/docs-partials/post-processor/alicloud-import/Config-not-required.mdx
@@ -2,8 +2,8 @@
 
 - `oss_key_name` (string) - The name of the object key in `oss_bucket_name` where the RAW or VHD
   file will be copied to for import. This is treated as a [template
-  engine](/docs/templates/legacy_json_templates/engine), and you may access any of the variables
-  stored in the generated data using the [build](/docs/templates/legacy_json_templates/engine)
+  engine](/packer/docs/templates/legacy_json_templates/engine), and you may access any of the variables
+  stored in the generated data using the [build](/packer/docs/templates/legacy_json_templates/engine)
   template function.
 
 - `skip_clean` (bool) - Whether we should skip removing the RAW or VHD file uploaded to OSS

--- a/docs/builders/alicloud-ecs.mdx
+++ b/docs/builders/alicloud-ecs.mdx
@@ -18,7 +18,7 @@ customized images based on an existing base images.
 
 The following configuration options are available for building Alicloud images.
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder.
 
 ### Required:

--- a/post-processor/alicloud-import/post-processor.go
+++ b/post-processor/alicloud-import/post-processor.go
@@ -64,8 +64,8 @@ type Config struct {
 	OSSBucket string `mapstructure:"oss_bucket_name" required:"true"`
 	// The name of the object key in `oss_bucket_name` where the RAW or VHD
 	// file will be copied to for import. This is treated as a [template
-	// engine](/docs/templates/legacy_json_templates/engine), and you may access any of the variables
-	// stored in the generated data using the [build](/docs/templates/legacy_json_templates/engine)
+	// engine](/packer/docs/templates/legacy_json_templates/engine), and you may access any of the variables
+	// stored in the generated data using the [build](/packer/docs/templates/legacy_json_templates/engine)
 	// template function.
 	OSSKey string `mapstructure:"oss_key_name"`
 	// Whether we should skip removing the RAW or VHD file uploaded to OSS


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them