### PR TITLE
Update builder.go

### DIFF
--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -138,7 +138,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	steps = append(steps,
 		&stepConfigAlicloudSecurityGroup{
 			SecurityGroupId:   b.config.SecurityGroupId,
-			SecurityGroupName: b.config.SecurityGroupId,
+			SecurityGroupName: b.config.SecurityGroupName,
 			RegionId:          b.config.AlicloudRegion,
 		},
 		&stepCreateAlicloudInstance{


### PR DESCRIPTION
The security group name is not properly passed to the downstream process

**DELETE THIS TEMPLATE BEFORE SUBMITTING**

In order to have a good experience with our community, we recommend that you
read the contributing guidelines for making a PR, and understand the lifecycle
of a Packer Plugin PR:

https://github.com/hashicorp/packer-plugin-alicloud/blob/main/.github/CONTRIBUTING.md#opening-an-pull-request

Describe the change you are making here!

Please include tests. We recommend looking at existing tests as an example. 

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx

