### PR TITLE
fix confused parameter ram_role_name to ecs_ram_role_name

### DIFF
--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -98,7 +98,7 @@ type FlatConfig struct {
 	SecurityGroupId                   *string                  `mapstructure:"security_group_id" required:"false" cty:"security_group_id" hcl:"security_group_id"`
 	SecurityGroupName                 *string                  `mapstructure:"security_group_name" required:"false" cty:"security_group_name" hcl:"security_group_name"`
 	SecurityEnhancementStrategy       *string                  `mapstructure:"security_enhancement_strategy" required:"false" cty:"security_enhancement_strategy" hcl:"security_enhancement_strategy"`
-	RamRoleName                   	  *string                  `mapstructure:"ecs_ram_role_name" required:"false" cty:"ecs_ram_role_name" hcl:"ecs_ram_role_name"`
+	RamRoleName                       *string                  `mapstructure:"ecs_ram_role_name" required:"false" cty:"ecs_ram_role_name" hcl:"ecs_ram_role_name"`
 	UserData                          *string                  `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	UserDataFile                      *string                  `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	VpcId                             *string                  `mapstructure:"vpc_id" required:"false" cty:"vpc_id" hcl:"vpc_id"`

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -98,6 +98,7 @@ type FlatConfig struct {
 	SecurityGroupId                   *string                  `mapstructure:"security_group_id" required:"false" cty:"security_group_id" hcl:"security_group_id"`
 	SecurityGroupName                 *string                  `mapstructure:"security_group_name" required:"false" cty:"security_group_name" hcl:"security_group_name"`
 	SecurityEnhancementStrategy       *string                  `mapstructure:"security_enhancement_strategy" required:"false" cty:"security_enhancement_strategy" hcl:"security_enhancement_strategy"`
+	RamRoleName                   	  *string                  `mapstructure:"ecs_ram_role_name" required:"false" cty:"ecs_ram_role_name" hcl:"ecs_ram_role_name"`
 	UserData                          *string                  `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	UserDataFile                      *string                  `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	VpcId                             *string                  `mapstructure:"vpc_id" required:"false" cty:"vpc_id" hcl:"vpc_id"`
@@ -225,6 +226,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"security_group_id":                &hcldec.AttrSpec{Name: "security_group_id", Type: cty.String, Required: false},
 		"security_group_name":              &hcldec.AttrSpec{Name: "security_group_name", Type: cty.String, Required: false},
 		"security_enhancement_strategy":    &hcldec.AttrSpec{Name: "security_enhancement_strategy", Type: cty.String, Required: false},
+		"ecs_ram_role_name":                &hcldec.AttrSpec{Name: "ecs_ram_role_name", Type: cty.String, Required: false},
 		"user_data":                        &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":                   &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
 		"vpc_id":                           &hcldec.AttrSpec{Name: "vpc_id", Type: cty.String, Required: false},

--- a/builder/ecs/run_config.go
+++ b/builder/ecs/run_config.go
@@ -51,7 +51,7 @@ type RunConfig struct {
 	// The default value is false.
 	DisableStopInstance bool `mapstructure:"disable_stop_instance" required:"false"`
 	// Ram Role to apply when launching the instance.
-	RamRoleName string `mapstructure:"ram_role_name" required:"false"`
+	RamRoleName string `mapstructure:"ecs_ram_role_name" required:"false"`
 	// Key/value pair tags to apply to the instance that is *launched*
 	// to create the image.
 	RunTags map[string]string `mapstructure:"run_tags" required:"false"`

--- a/docs-partials/builder/ecs/RunConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/RunConfig-not-required.mdx
@@ -24,7 +24,7 @@
   E.g., Sysprep a windows which may shutdown the instance within its command.
   The default value is false.
 
-- `ram_role_name` (string) - Ram Role to apply when launching the instance.
+- `ecs_ram_role_name` (string) - Ram Role to apply when launching the instance.
 
 - `run_tags` (map[string]string) - Key/value pair tags to apply to the instance that is *launched*
   to create the image.

--- a/post-processor/alicloud-import/post-processor.hcl2spec.go
+++ b/post-processor/alicloud-import/post-processor.hcl2spec.go
@@ -62,6 +62,7 @@ type FlatConfig struct {
 	SecurityGroupId                   *string                      `mapstructure:"security_group_id" required:"false" cty:"security_group_id" hcl:"security_group_id"`
 	SecurityGroupName                 *string                      `mapstructure:"security_group_name" required:"false" cty:"security_group_name" hcl:"security_group_name"`
 	SecurityEnhancementStrategy       *string                      `mapstructure:"security_enhancement_strategy" required:"false" cty:"security_enhancement_strategy" hcl:"security_enhancement_strategy"`
+	RamRoleName                   	  *string                  	   `mapstructure:"ecs_ram_role_name" required:"false" cty:"ecs_ram_role_name" hcl:"ecs_ram_role_name"`
 	UserData                          *string                      `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	UserDataFile                      *string                      `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	VpcId                             *string                      `mapstructure:"vpc_id" required:"false" cty:"vpc_id" hcl:"vpc_id"`
@@ -197,6 +198,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"security_group_id":                &hcldec.AttrSpec{Name: "security_group_id", Type: cty.String, Required: false},
 		"security_group_name":              &hcldec.AttrSpec{Name: "security_group_name", Type: cty.String, Required: false},
 		"security_enhancement_strategy":    &hcldec.AttrSpec{Name: "security_enhancement_strategy", Type: cty.String, Required: false},
+		"ecs_ram_role_name":                &hcldec.AttrSpec{Name: "ecs_ram_role_name", Type: cty.String, Required: false},
 		"user_data":                        &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":                   &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
 		"vpc_id":                           &hcldec.AttrSpec{Name: "vpc_id", Type: cty.String, Required: false},

--- a/post-processor/alicloud-import/post-processor.hcl2spec.go
+++ b/post-processor/alicloud-import/post-processor.hcl2spec.go
@@ -62,7 +62,7 @@ type FlatConfig struct {
 	SecurityGroupId                   *string                      `mapstructure:"security_group_id" required:"false" cty:"security_group_id" hcl:"security_group_id"`
 	SecurityGroupName                 *string                      `mapstructure:"security_group_name" required:"false" cty:"security_group_name" hcl:"security_group_name"`
 	SecurityEnhancementStrategy       *string                      `mapstructure:"security_enhancement_strategy" required:"false" cty:"security_enhancement_strategy" hcl:"security_enhancement_strategy"`
-	RamRoleName                   	  *string                  	   `mapstructure:"ecs_ram_role_name" required:"false" cty:"ecs_ram_role_name" hcl:"ecs_ram_role_name"`
+	RamRoleName                       *string                      `mapstructure:"ecs_ram_role_name" required:"false" cty:"ecs_ram_role_name" hcl:"ecs_ram_role_name"`
 	UserData                          *string                      `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	UserDataFile                      *string                      `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	VpcId                             *string                      `mapstructure:"vpc_id" required:"false" cty:"vpc_id" hcl:"vpc_id"`


### PR DESCRIPTION
fix confused parameter ram_role_name which works for credential and launching instance.
ram_role_name will only work for credential. ecs_ram_role_name will only work for launching instance.