### PR TITLE
Fix naming conflict for ram_role_name

### DIFF
--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -146,7 +146,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			InstanceType:                b.config.InstanceType,
 			UserData:                    b.config.UserData,
 			UserDataFile:                b.config.UserDataFile,
-			RamRoleName:                 b.config.RamRoleName,
+			InstanceRamRole:             b.config.InstanceRamRole,
 			Tags:                        b.config.RunTags,
 			RegionId:                    b.config.AlicloudRegion,
 			InternetChargeType:          b.config.InternetChargeType,

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -94,6 +94,7 @@ type FlatConfig struct {
 	AlicloudImageFamily               *string                  `mapstructure:"image_family" required:"true" cty:"image_family" hcl:"image_family"`
 	ForceStopInstance                 *bool                    `mapstructure:"force_stop_instance" required:"false" cty:"force_stop_instance" hcl:"force_stop_instance"`
 	DisableStopInstance               *bool                    `mapstructure:"disable_stop_instance" required:"false" cty:"disable_stop_instance" hcl:"disable_stop_instance"`
+	InstanceRamRole                   *string                  `mapstructure:"instance_ram_role" required:"false" cty:"instance_ram_role" hcl:"instance_ram_role"`
 	RunTags                           map[string]string        `mapstructure:"run_tags" required:"false" cty:"run_tags" hcl:"run_tags"`
 	SecurityGroupId                   *string                  `mapstructure:"security_group_id" required:"false" cty:"security_group_id" hcl:"security_group_id"`
 	SecurityGroupName                 *string                  `mapstructure:"security_group_name" required:"false" cty:"security_group_name" hcl:"security_group_name"`
@@ -159,8 +160,8 @@ type FlatConfig struct {
 	WinRMUseSSL                       *bool                    `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure                     *bool                    `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM                      *bool                    `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
-	SkipCreateImage                   *bool                    `mapstructure:"skip_create_image" cty:"skip_create_image" hcl:"skip_create_image"`
 	SSHPrivateIp                      *bool                    `mapstructure:"ssh_private_ip" required:"false" cty:"ssh_private_ip" hcl:"ssh_private_ip"`
+	SkipCreateImage                   *bool                    `mapstructure:"skip_create_image" required:"false" cty:"skip_create_image" hcl:"skip_create_image"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -221,6 +222,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_family":                     &hcldec.AttrSpec{Name: "image_family", Type: cty.String, Required: false},
 		"force_stop_instance":              &hcldec.AttrSpec{Name: "force_stop_instance", Type: cty.Bool, Required: false},
 		"disable_stop_instance":            &hcldec.AttrSpec{Name: "disable_stop_instance", Type: cty.Bool, Required: false},
+		"instance_ram_role":                &hcldec.AttrSpec{Name: "instance_ram_role", Type: cty.String, Required: false},
 		"run_tags":                         &hcldec.AttrSpec{Name: "run_tags", Type: cty.Map(cty.String), Required: false},
 		"security_group_id":                &hcldec.AttrSpec{Name: "security_group_id", Type: cty.String, Required: false},
 		"security_group_name":              &hcldec.AttrSpec{Name: "security_group_name", Type: cty.String, Required: false},
@@ -286,8 +288,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                    &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":                   &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":                   &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
-		"skip_create_image":                &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},
 		"ssh_private_ip":                   &hcldec.AttrSpec{Name: "ssh_private_ip", Type: cty.Bool, Required: false},
+		"skip_create_image":                &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/ecs/run_config.go
+++ b/builder/ecs/run_config.go
@@ -50,8 +50,8 @@ type RunConfig struct {
 	// E.g., Sysprep a windows which may shutdown the instance within its command.
 	// The default value is false.
 	DisableStopInstance bool `mapstructure:"disable_stop_instance" required:"false"`
-	// Ram Role to apply when launching the instance.
-	RamRoleName string `mapstructure:"ram_role_name" required:"false"`
+	// The name of an RAM role to launch the instance with.
+	InstanceRamRole string `mapstructure:"instance_ram_role" required:"false"`
 	// Key/value pair tags to apply to the instance that is *launched*
 	// to create the image.
 	RunTags map[string]string `mapstructure:"run_tags" required:"false"`

--- a/builder/ecs/step_create_instance.go
+++ b/builder/ecs/step_create_instance.go
@@ -22,7 +22,7 @@ type stepCreateAlicloudInstance struct {
 	InstanceType                string
 	UserData                    string
 	UserDataFile                string
-	RamRoleName                 string
+	InstanceRamRole             string
 	Tags                        map[string]string
 	RegionId                    string
 	InternetChargeType          string
@@ -118,7 +118,7 @@ func (s *stepCreateAlicloudInstance) buildCreateInstanceRequest(state multistep.
 	request.RegionId = s.RegionId
 	request.InstanceType = s.InstanceType
 	request.InstanceName = s.InstanceName
-	request.RamRoleName = s.RamRoleName
+	request.RamRoleName = s.InstanceRamRole
 	request.Tag = buildCreateInstanceTags(s.Tags)
 	request.ZoneId = s.ZoneId
 	request.SecurityEnhancementStrategy = s.SecurityEnhancementStrategy

--- a/docs-partials/builder/ecs/RunConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/RunConfig-not-required.mdx
@@ -24,7 +24,7 @@
   E.g., Sysprep a windows which may shutdown the instance within its command.
   The default value is false.
 
-- `ram_role_name` (string) - Ram Role to apply when launching the instance.
+- `instance_ram_role` (string) - The name of an RAM role to launch the instance with.
 
 - `run_tags` (map[string]string) - Key/value pair tags to apply to the instance that is *launched*
   to create the image.

--- a/post-processor/alicloud-import/post-processor.hcl2spec.go
+++ b/post-processor/alicloud-import/post-processor.hcl2spec.go
@@ -58,6 +58,7 @@ type FlatConfig struct {
 	AlicloudImageFamily               *string                      `mapstructure:"image_family" required:"true" cty:"image_family" hcl:"image_family"`
 	ForceStopInstance                 *bool                        `mapstructure:"force_stop_instance" required:"false" cty:"force_stop_instance" hcl:"force_stop_instance"`
 	DisableStopInstance               *bool                        `mapstructure:"disable_stop_instance" required:"false" cty:"disable_stop_instance" hcl:"disable_stop_instance"`
+	InstanceRamRole                   *string                      `mapstructure:"instance_ram_role" required:"false" cty:"instance_ram_role" hcl:"instance_ram_role"`
 	RunTags                           map[string]string            `mapstructure:"run_tags" required:"false" cty:"run_tags" hcl:"run_tags"`
 	SecurityGroupId                   *string                      `mapstructure:"security_group_id" required:"false" cty:"security_group_id" hcl:"security_group_id"`
 	SecurityGroupName                 *string                      `mapstructure:"security_group_name" required:"false" cty:"security_group_name" hcl:"security_group_name"`
@@ -123,8 +124,8 @@ type FlatConfig struct {
 	WinRMUseSSL                       *bool                        `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure                     *bool                        `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM                      *bool                        `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
-	SkipCreateImage                   *bool                        `mapstructure:"skip_create_image" cty:"skip_create_image" hcl:"skip_create_image"`
 	SSHPrivateIp                      *bool                        `mapstructure:"ssh_private_ip" required:"false" cty:"ssh_private_ip" hcl:"ssh_private_ip"`
+	SkipCreateImage                   *bool                        `mapstructure:"skip_create_image" required:"false" cty:"skip_create_image" hcl:"skip_create_image"`
 	OSSBucket                         *string                      `mapstructure:"oss_bucket_name" required:"true" cty:"oss_bucket_name" hcl:"oss_bucket_name"`
 	OSSKey                            *string                      `mapstructure:"oss_key_name" cty:"oss_key_name" hcl:"oss_key_name"`
 	SkipClean                         *bool                        `mapstructure:"skip_clean" cty:"skip_clean" hcl:"skip_clean"`
@@ -193,6 +194,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_family":                     &hcldec.AttrSpec{Name: "image_family", Type: cty.String, Required: false},
 		"force_stop_instance":              &hcldec.AttrSpec{Name: "force_stop_instance", Type: cty.Bool, Required: false},
 		"disable_stop_instance":            &hcldec.AttrSpec{Name: "disable_stop_instance", Type: cty.Bool, Required: false},
+		"instance_ram_role":                &hcldec.AttrSpec{Name: "instance_ram_role", Type: cty.String, Required: false},
 		"run_tags":                         &hcldec.AttrSpec{Name: "run_tags", Type: cty.Map(cty.String), Required: false},
 		"security_group_id":                &hcldec.AttrSpec{Name: "security_group_id", Type: cty.String, Required: false},
 		"security_group_name":              &hcldec.AttrSpec{Name: "security_group_name", Type: cty.String, Required: false},
@@ -258,8 +260,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                    &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":                   &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":                   &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
-		"skip_create_image":                &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},
 		"ssh_private_ip":                   &hcldec.AttrSpec{Name: "ssh_private_ip", Type: cty.Bool, Required: false},
+		"skip_create_image":                &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},
 		"oss_bucket_name":                  &hcldec.AttrSpec{Name: "oss_bucket_name", Type: cty.String, Required: false},
 		"oss_key_name":                     &hcldec.AttrSpec{Name: "oss_key_name", Type: cty.String, Required: false},
 		"skip_clean":                       &hcldec.AttrSpec{Name: "skip_clean", Type: cty.Bool, Required: false},


### PR DESCRIPTION
Currently `ram_role_name` is used in two places:

1. ram_role_name (string) - Alicloud RamRole must be provided for EcsRamRole mode unless profile is set.
2. ram_role_name (string) - Ram Role to apply when launching the instance.

In reality, they don't need to be the same role. We should be able to use RAM role A to launch a running instance which has RAM role B attached to.


Meanwhile, I'm open to the naming of this field, `instance_ram_role` is the best name that I could think of for this field.
Please feel free to make a suggestion.

Thank you!


