### PR TITLE
add doc section for the required_plugins of alicloud

### DIFF
--- a/docs/builders/alicloud-ecs.mdx
+++ b/docs/builders/alicloud-ecs.mdx
@@ -14,6 +14,48 @@ Artifact BuilderId: `alibaba.alicloud`
 The `alicloud-ecs` Packer builder plugin provide the capability to build
 customized images based on an existing base images.
 
+## Installation
+
+### Using pre-built releases
+
+#### Using the `packer init` command
+
+Starting from version 1.7, Packer supports a new `packer init` command allowing
+automatic installation of Packer plugins. Read the
+[Packer documentation](https://www.packer.io/docs/commands/init) for more information.
+
+To install this plugin, copy and paste this code into your Packer configuration .
+Then, run [`packer init`](https://www.packer.io/docs/commands/init).
+
+```hcl
+packer {
+  required_plugins {
+    alicloud = {
+      version = ">= 1.1.0"
+      source  = "github.com/hashicorp/alicloud"
+    }
+  }
+}
+```
+
+#### Manual installation
+
+You can find pre-built binary releases of the plugin [here](https://github.com/hashicorp/packer-plugin-alicloud/releases).
+Once you have downloaded the latest archive corresponding to your target OS,
+uncompress it to retrieve the plugin binary file corresponding to your platform.
+To install the plugin, please follow the Packer documentation on
+[installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+
+#### From Source
+
+If you prefer to build the plugin from its source code, clone the GitHub
+repository locally and run the command `go build` from the root
+directory. Upon successful compilation, a `packer-plugin-alicloud` plugin
+binary file can be found in the root directory.
+To install the compiled plugin, please follow the official Packer documentation
+on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+
+
 ## Configuration Reference
 
 The following configuration options are available for building Alicloud images.


### PR DESCRIPTION
The `required_plugins` section is missing in the doc.

Basically added the short reference for
```hcl
packer {
  required_plugins {
    alicloud = {
      version = ">= 1.1.0"
      source  = "github.com/hashicorp/alicloud"
    }
  }
}
```

mostly referenced from https://raw.githubusercontent.com/hashicorp/packer-plugin-jdcloud/main/docs/README.md



