### PR TITLE
Added feature to build using an Existing available EIP (Elastic IP)

### DIFF
--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -166,6 +166,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			InternetChargeType:       b.config.InternetChargeType,
 			InternetMaxBandwidthOut:  b.config.InternetMaxBandwidthOut,
 			SSHPrivateIp:             b.config.SSHPrivateIp,
+			EipId:					  b.config.EipId,
 		})
 	} else {
 		steps = append(steps, &stepConfigAlicloudPublicIP{

--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -166,7 +166,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			InternetChargeType:       b.config.InternetChargeType,
 			InternetMaxBandwidthOut:  b.config.InternetMaxBandwidthOut,
 			SSHPrivateIp:             b.config.SSHPrivateIp,
-			EipId:					  b.config.EipId,
+			EipId:                    b.config.EipId,
 		})
 	} else {
 		steps = append(steps, &stepConfigAlicloudPublicIP{

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -103,6 +103,7 @@ type FlatConfig struct {
 	UserDataFile                      *string                  `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	VpcId                             *string                  `mapstructure:"vpc_id" required:"false" cty:"vpc_id" hcl:"vpc_id"`
 	VpcName                           *string                  `mapstructure:"vpc_name" required:"false" cty:"vpc_name" hcl:"vpc_name"`
+	EipId							  *string				   `mapstructure:"eip_id" required:"false" cty:"eip_id" hcl:"eip_id"`
 	CidrBlock                         *string                  `mapstructure:"vpc_cidr_block" required:"false" cty:"vpc_cidr_block" hcl:"vpc_cidr_block"`
 	VSwitchId                         *string                  `mapstructure:"vswitch_id" required:"false" cty:"vswitch_id" hcl:"vswitch_id"`
 	VSwitchName                       *string                  `mapstructure:"vswitch_name" required:"false" cty:"vswitch_name" hcl:"vswitch_name"`
@@ -231,6 +232,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"user_data_file":                   &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
 		"vpc_id":                           &hcldec.AttrSpec{Name: "vpc_id", Type: cty.String, Required: false},
 		"vpc_name":                         &hcldec.AttrSpec{Name: "vpc_name", Type: cty.String, Required: false},
+		"eip_id":                           &hcldec.AttrSpec{Name: "eip_id", Type: cty.String, Required: false},
 		"vpc_cidr_block":                   &hcldec.AttrSpec{Name: "vpc_cidr_block", Type: cty.String, Required: false},
 		"vswitch_id":                       &hcldec.AttrSpec{Name: "vswitch_id", Type: cty.String, Required: false},
 		"vswitch_name":                     &hcldec.AttrSpec{Name: "vswitch_name", Type: cty.String, Required: false},

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -103,10 +103,10 @@ type FlatConfig struct {
 	UserDataFile                      *string                  `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	VpcId                             *string                  `mapstructure:"vpc_id" required:"false" cty:"vpc_id" hcl:"vpc_id"`
 	VpcName                           *string                  `mapstructure:"vpc_name" required:"false" cty:"vpc_name" hcl:"vpc_name"`
-	EipId							  *string				   `mapstructure:"eip_id" required:"false" cty:"eip_id" hcl:"eip_id"`
 	CidrBlock                         *string                  `mapstructure:"vpc_cidr_block" required:"false" cty:"vpc_cidr_block" hcl:"vpc_cidr_block"`
 	VSwitchId                         *string                  `mapstructure:"vswitch_id" required:"false" cty:"vswitch_id" hcl:"vswitch_id"`
 	VSwitchName                       *string                  `mapstructure:"vswitch_name" required:"false" cty:"vswitch_name" hcl:"vswitch_name"`
+	EipId                             *string                  `mapstructure:"eip_id" required:"false" cty:"eip_id" hcl:"eip_id"`
 	InstanceName                      *string                  `mapstructure:"instance_name" required:"false" cty:"instance_name" hcl:"instance_name"`
 	InternetChargeType                *string                  `mapstructure:"internet_charge_type" required:"false" cty:"internet_charge_type" hcl:"internet_charge_type"`
 	InternetMaxBandwidthOut           *int                     `mapstructure:"internet_max_bandwidth_out" required:"false" cty:"internet_max_bandwidth_out" hcl:"internet_max_bandwidth_out"`
@@ -232,10 +232,10 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"user_data_file":                   &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
 		"vpc_id":                           &hcldec.AttrSpec{Name: "vpc_id", Type: cty.String, Required: false},
 		"vpc_name":                         &hcldec.AttrSpec{Name: "vpc_name", Type: cty.String, Required: false},
-		"eip_id":                           &hcldec.AttrSpec{Name: "eip_id", Type: cty.String, Required: false},
 		"vpc_cidr_block":                   &hcldec.AttrSpec{Name: "vpc_cidr_block", Type: cty.String, Required: false},
 		"vswitch_id":                       &hcldec.AttrSpec{Name: "vswitch_id", Type: cty.String, Required: false},
 		"vswitch_name":                     &hcldec.AttrSpec{Name: "vswitch_name", Type: cty.String, Required: false},
+		"eip_id":                           &hcldec.AttrSpec{Name: "eip_id", Type: cty.String, Required: false},
 		"instance_name":                    &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
 		"internet_charge_type":             &hcldec.AttrSpec{Name: "internet_charge_type", Type: cty.String, Required: false},
 		"internet_max_bandwidth_out":       &hcldec.AttrSpec{Name: "internet_max_bandwidth_out", Type: cty.Number, Required: false},

--- a/builder/ecs/run_config.go
+++ b/builder/ecs/run_config.go
@@ -98,6 +98,8 @@ type RunConfig struct {
 	VSwitchId string `mapstructure:"vswitch_id" required:"false"`
 	// The ID of the VSwitch to be used.
 	VSwitchName string `mapstructure:"vswitch_name" required:"false"`
+	//The ID of the EIP to be used as public ip for the instance
+	EipId string `mapstructure:"eip_id" required:"false"`
 	// Display name of the instance, which is a string of 2 to 128 Chinese or
 	// English characters. It must begin with an uppercase/lowercase letter or
 	// a Chinese character and can contain numerals, `.`, `_`, or `-`. The

--- a/docs-partials/builder/ecs/RunConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/RunConfig-not-required.mdx
@@ -69,6 +69,8 @@
 
 - `vswitch_name` (string) - The ID of the VSwitch to be used.
 
+- `eip_id` (string) - The ID of the EIP to be used as public ip for the instance
+
 - `instance_name` (string) - Display name of the instance, which is a string of 2 to 128 Chinese or
   English characters. It must begin with an uppercase/lowercase letter or
   a Chinese character and can contain numerals, `.`, `_`, or `-`. The

--- a/post-processor/alicloud-import/post-processor.hcl2spec.go
+++ b/post-processor/alicloud-import/post-processor.hcl2spec.go
@@ -67,10 +67,10 @@ type FlatConfig struct {
 	UserDataFile                      *string                      `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	VpcId                             *string                      `mapstructure:"vpc_id" required:"false" cty:"vpc_id" hcl:"vpc_id"`
 	VpcName                           *string                      `mapstructure:"vpc_name" required:"false" cty:"vpc_name" hcl:"vpc_name"`
-	EipId 							  *string 					   `mapstructure:"eip_id" required:"false" cty:"eip_id" hcl:"eip_id"`
 	CidrBlock                         *string                      `mapstructure:"vpc_cidr_block" required:"false" cty:"vpc_cidr_block" hcl:"vpc_cidr_block"`
 	VSwitchId                         *string                      `mapstructure:"vswitch_id" required:"false" cty:"vswitch_id" hcl:"vswitch_id"`
 	VSwitchName                       *string                      `mapstructure:"vswitch_name" required:"false" cty:"vswitch_name" hcl:"vswitch_name"`
+	EipId                             *string                      `mapstructure:"eip_id" required:"false" cty:"eip_id" hcl:"eip_id"`
 	InstanceName                      *string                      `mapstructure:"instance_name" required:"false" cty:"instance_name" hcl:"instance_name"`
 	InternetChargeType                *string                      `mapstructure:"internet_charge_type" required:"false" cty:"internet_charge_type" hcl:"internet_charge_type"`
 	InternetMaxBandwidthOut           *int                         `mapstructure:"internet_max_bandwidth_out" required:"false" cty:"internet_max_bandwidth_out" hcl:"internet_max_bandwidth_out"`
@@ -204,10 +204,10 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"user_data_file":                   &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
 		"vpc_id":                           &hcldec.AttrSpec{Name: "vpc_id", Type: cty.String, Required: false},
 		"vpc_name":                         &hcldec.AttrSpec{Name: "vpc_name", Type: cty.String, Required: false},
-		"eip_id":							&hcldec.AttrSpec{Name: "eip_id", Type: cty.String, Required: false},
 		"vpc_cidr_block":                   &hcldec.AttrSpec{Name: "vpc_cidr_block", Type: cty.String, Required: false},
 		"vswitch_id":                       &hcldec.AttrSpec{Name: "vswitch_id", Type: cty.String, Required: false},
 		"vswitch_name":                     &hcldec.AttrSpec{Name: "vswitch_name", Type: cty.String, Required: false},
+		"eip_id":                           &hcldec.AttrSpec{Name: "eip_id", Type: cty.String, Required: false},
 		"instance_name":                    &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
 		"internet_charge_type":             &hcldec.AttrSpec{Name: "internet_charge_type", Type: cty.String, Required: false},
 		"internet_max_bandwidth_out":       &hcldec.AttrSpec{Name: "internet_max_bandwidth_out", Type: cty.Number, Required: false},

--- a/post-processor/alicloud-import/post-processor.hcl2spec.go
+++ b/post-processor/alicloud-import/post-processor.hcl2spec.go
@@ -67,6 +67,7 @@ type FlatConfig struct {
 	UserDataFile                      *string                      `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	VpcId                             *string                      `mapstructure:"vpc_id" required:"false" cty:"vpc_id" hcl:"vpc_id"`
 	VpcName                           *string                      `mapstructure:"vpc_name" required:"false" cty:"vpc_name" hcl:"vpc_name"`
+	EipId 							  *string 					   `mapstructure:"eip_id" required:"false" cty:"eip_id" hcl:"eip_id"`
 	CidrBlock                         *string                      `mapstructure:"vpc_cidr_block" required:"false" cty:"vpc_cidr_block" hcl:"vpc_cidr_block"`
 	VSwitchId                         *string                      `mapstructure:"vswitch_id" required:"false" cty:"vswitch_id" hcl:"vswitch_id"`
 	VSwitchName                       *string                      `mapstructure:"vswitch_name" required:"false" cty:"vswitch_name" hcl:"vswitch_name"`
@@ -203,6 +204,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"user_data_file":                   &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
 		"vpc_id":                           &hcldec.AttrSpec{Name: "vpc_id", Type: cty.String, Required: false},
 		"vpc_name":                         &hcldec.AttrSpec{Name: "vpc_name", Type: cty.String, Required: false},
+		"eip_id":							&hcldec.AttrSpec{Name: "eip_id", Type: cty.String, Required: false},
 		"vpc_cidr_block":                   &hcldec.AttrSpec{Name: "vpc_cidr_block", Type: cty.String, Required: false},
 		"vswitch_id":                       &hcldec.AttrSpec{Name: "vswitch_id", Type: cty.String, Required: false},
 		"vswitch_name":                     &hcldec.AttrSpec{Name: "vswitch_name", Type: cty.String, Required: false},


### PR DESCRIPTION
Added the possibility to create an image build using an existing available EIP instead of allocating a new one.

Why this feature:
Currently it's possible to build using existing network infrastructure such as VPC and Vswitch and security groups, we are using this - yet we are also using Cloud firewall and here we need some custom rules for image build VM's to work.
By having a pool of Known before IP addresses we can apply the firewall rules to them, then we just need to use any available EIP from that pool during the build process.