### PR TITLE
clean up the private key file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ packer-plugin-alicloud
 .idea
 
 crash.log
+vendor/

--- a/.web-docs/components/builder/alicloud-ecs/README.md
+++ b/.web-docs/components/builder/alicloud-ecs/README.md
@@ -315,6 +315,8 @@ builder.
 
 - `kms_key_id` (string) - The source image KMS key ID used to encrypt the disk.
 
+- `image_delete_ssh_private_key` (bool) - If set to true, the ECS keypair information will be removed. The default value is false.
+
 <!-- End of code generated from the comments of the AlicloudImageConfig struct in builder/ecs/image_config.go; -->
 
 

--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -188,6 +188,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&commonsteps.StepCleanupTempKeys{
 			Comm: &b.config.RunConfig.Comm,
 		},
+		&stepImageDeleteSSHPrivateKey{
+			AlicloudImageDeleteSSHPrivateKey: b.config.AlicloudImageDeleteSSHPrivateKey,
+		},
 		&stepStopAlicloudInstance{
 			ForceStop:   b.config.ForceStopInstance,
 			DisableStop: b.config.DisableStopInstance,

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -90,6 +90,7 @@ type FlatConfig struct {
 	AlicloudBootMode                  *string                  `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
 	AlicloudKMSKeyCopyIds             []string                 `mapstructure:"kms_key_copy_ids" required:"false" cty:"kms_key_copy_ids" hcl:"kms_key_copy_ids"`
 	AlicloudKMSKeyId                  *string                  `mapstructure:"kms_key_id" required:"false" cty:"kms_key_id" hcl:"kms_key_id"`
+	AlicloudImageDeleteSSHPrivateKey  *bool                    `mapstructure:"image_delete_ssh_private_key" required:"false" cty:"image_delete_ssh_private_key" hcl:"image_delete_ssh_private_key"`
 	AssociatePublicIpAddress          *bool                    `mapstructure:"associate_public_ip_address" cty:"associate_public_ip_address" hcl:"associate_public_ip_address"`
 	ZoneId                            *string                  `mapstructure:"zone_id" required:"false" cty:"zone_id" hcl:"zone_id"`
 	IOOptimized                       *bool                    `mapstructure:"io_optimized" required:"false" cty:"io_optimized" hcl:"io_optimized"`
@@ -224,6 +225,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"boot_mode":                        &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
 		"kms_key_copy_ids":                 &hcldec.AttrSpec{Name: "kms_key_copy_ids", Type: cty.List(cty.String), Required: false},
 		"kms_key_id":                       &hcldec.AttrSpec{Name: "kms_key_id", Type: cty.String, Required: false},
+		"image_delete_ssh_private_key":     &hcldec.AttrSpec{Name: "image_delete_ssh_private_key", Type: cty.Bool, Required: false},
 		"associate_public_ip_address":      &hcldec.AttrSpec{Name: "associate_public_ip_address", Type: cty.Bool, Required: false},
 		"zone_id":                          &hcldec.AttrSpec{Name: "zone_id", Type: cty.String, Required: false},
 		"io_optimized":                     &hcldec.AttrSpec{Name: "io_optimized", Type: cty.Bool, Required: false},

--- a/builder/ecs/image_config.go
+++ b/builder/ecs/image_config.go
@@ -172,6 +172,8 @@ type AlicloudImageConfig struct {
 	AlicloudKMSKeyCopyIds []string `mapstructure:"kms_key_copy_ids" required:"false"`
 	// The source image KMS key ID used to encrypt the disk.
 	AlicloudKMSKeyId string `mapstructure:"kms_key_id" required:"false"`
+	// If set to true, the ECS keypair information will be removed. The default value is false.
+	AlicloudImageDeleteSSHPrivateKey bool `mapstructure:"image_delete_ssh_private_key" required:"false"`
 }
 
 func (c *AlicloudImageConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/ecs/step_image_delete_ssh_private_key.go
+++ b/builder/ecs/step_image_delete_ssh_private_key.go
@@ -1,0 +1,59 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ecs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+type stepImageDeleteSSHPrivateKey struct {
+	AlicloudImageDeleteSSHPrivateKey bool
+}
+
+func (s *stepImageDeleteSSHPrivateKey) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packersdk.Ui)
+	client := state.Get("client").(*ClientWrapper)
+	config := state.Get("config").(*Config)
+	instance := state.Get("instance").(*ecs.Instance)
+	keyPairName := config.Comm.SSHKeyPairName
+
+	// Check for force delete
+	if s.AlicloudImageDeleteSSHPrivateKey {
+		if keyPairName == "" {
+			return multistep.ActionContinue
+		}
+		detachKeyPairRequest := ecs.CreateDetachKeyPairRequest()
+		detachKeyPairRequest.RegionId = config.AlicloudRegion
+		detachKeyPairRequest.KeyPairName = keyPairName
+		detachKeyPairRequest.InstanceIds = fmt.Sprintf("[\"%s\"]", instance.InstanceId)
+
+		if _, err := client.DetachKeyPair(detachKeyPairRequest); err != nil {
+			return halt(state, err, fmt.Sprintf("Error Detaching keypair %s to instance %s", keyPairName, instance.InstanceId))
+		}
+		ui.Say(fmt.Sprintf("Detach keypair %s from instance: %s", keyPairName, instance.InstanceId))
+
+		rebootInstanceRequest := ecs.CreateRebootInstanceRequest()
+		rebootInstanceRequest.InstanceId = instance.InstanceId
+		if _, err := client.RebootInstance(rebootInstanceRequest); err != nil {
+			return halt(state, err, "Error reboot instance")
+		}
+
+		_, err := client.WaitForInstanceStatus(instance.RegionId, instance.InstanceId, InstanceStatusRunning)
+		if err != nil {
+			return halt(state, err, "Timeout waiting for instance to reboot")
+		}
+		ui.Say(fmt.Sprintf("Reboot instance: %s", instance.InstanceId))
+
+	}
+	return multistep.ActionContinue
+}
+
+func (s *stepImageDeleteSSHPrivateKey) Cleanup(multistep.StateBag) {
+	// No cleanup...
+}

--- a/docs-partials/builder/ecs/AlicloudImageConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/AlicloudImageConfig-not-required.mdx
@@ -69,4 +69,6 @@
 
 - `kms_key_id` (string) - The source image KMS key ID used to encrypt the disk.
 
+- `image_delete_ssh_private_key` (bool) - If set to true, the ECS keypair information will be removed. The default value is false.
+
 <!-- End of code generated from the comments of the AlicloudImageConfig struct in builder/ecs/image_config.go; -->

--- a/post-processor/alicloud-import/post-processor.hcl2spec.go
+++ b/post-processor/alicloud-import/post-processor.hcl2spec.go
@@ -54,6 +54,7 @@ type FlatConfig struct {
 	AlicloudBootMode                  *string                      `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
 	AlicloudKMSKeyCopyIds             []string                     `mapstructure:"kms_key_copy_ids" required:"false" cty:"kms_key_copy_ids" hcl:"kms_key_copy_ids"`
 	AlicloudKMSKeyId                  *string                      `mapstructure:"kms_key_id" required:"false" cty:"kms_key_id" hcl:"kms_key_id"`
+	AlicloudImageDeleteSSHPrivateKey  *bool                        `mapstructure:"image_delete_ssh_private_key" required:"false" cty:"image_delete_ssh_private_key" hcl:"image_delete_ssh_private_key"`
 	AssociatePublicIpAddress          *bool                        `mapstructure:"associate_public_ip_address" cty:"associate_public_ip_address" hcl:"associate_public_ip_address"`
 	ZoneId                            *string                      `mapstructure:"zone_id" required:"false" cty:"zone_id" hcl:"zone_id"`
 	IOOptimized                       *bool                        `mapstructure:"io_optimized" required:"false" cty:"io_optimized" hcl:"io_optimized"`
@@ -196,6 +197,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"boot_mode":                        &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
 		"kms_key_copy_ids":                 &hcldec.AttrSpec{Name: "kms_key_copy_ids", Type: cty.List(cty.String), Required: false},
 		"kms_key_id":                       &hcldec.AttrSpec{Name: "kms_key_id", Type: cty.String, Required: false},
+		"image_delete_ssh_private_key":     &hcldec.AttrSpec{Name: "image_delete_ssh_private_key", Type: cty.Bool, Required: false},
 		"associate_public_ip_address":      &hcldec.AttrSpec{Name: "associate_public_ip_address", Type: cty.Bool, Required: false},
 		"zone_id":                          &hcldec.AttrSpec{Name: "zone_id", Type: cty.String, Required: false},
 		"io_optimized":                     &hcldec.AttrSpec{Name: "io_optimized", Type: cty.Bool, Required: false},


### PR DESCRIPTION
New Parameter: image_delete_ssh_private_key
Description:
After connecting to the ECS instance via SSH key, this parameter determines whether to clean up the SSH key information on the intermediate ECS instance based on its value.
true: The .ssh/authorized_keys file in the final custom image will be empty.
false: The .ssh/authorized_keys file in the final custom image will retain the SSH key information.