### PR TITLE
refactor: replace RunInstances API with CreateInstance API for ECS

### DIFF
--- a/.web-docs/components/builder/alicloud-ecs/README.md
+++ b/.web-docs/components/builder/alicloud-ecs/README.md
@@ -311,10 +311,6 @@ builder.
 
 - `boot_mode` (string) - The boot mode of the user-defined image, it should to be one of 'BIOS', 'UEFI' or 'UEFI-Preferred'.
 
-- `kms_key_copy_ids` ([]string) - Copy to the destination KMS key ID array
-
-- `kms_key_id` (string) - The source image KMS key ID used to encrypt the disk.
-
 - `image_delete_ssh_private_key` (bool) - If set to true, the ECS keypair information will be removed. The default value is false.
 
 <!-- End of code generated from the comments of the AlicloudImageConfig struct in builder/ecs/image_config.go; -->

--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -222,7 +222,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			&stepRegionCopyAlicloudImage{
 				AlicloudImageDestinationRegions: b.config.AlicloudImageDestinationRegions,
 				AlicloudImageDestinationNames:   b.config.AlicloudImageDestinationNames,
-				KmsKeyIds:                       b.config.AlicloudKMSKeyCopyIds,
 				RegionId:                        b.config.AlicloudRegion,
 				WaitCopyingImageReadyTimeout:    b.getCopyingImageReadyTimeout(),
 			},

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -88,8 +88,6 @@ type FlatConfig struct {
 	ECSImagesDiskMappings             []FlatAlicloudDiskDevice `mapstructure:"image_disk_mappings" required:"false" cty:"image_disk_mappings" hcl:"image_disk_mappings"`
 	AlicloudTargetImageFamily         *string                  `mapstructure:"target_image_family" required:"false" cty:"target_image_family" hcl:"target_image_family"`
 	AlicloudBootMode                  *string                  `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
-	AlicloudKMSKeyCopyIds             []string                 `mapstructure:"kms_key_copy_ids" required:"false" cty:"kms_key_copy_ids" hcl:"kms_key_copy_ids"`
-	AlicloudKMSKeyId                  *string                  `mapstructure:"kms_key_id" required:"false" cty:"kms_key_id" hcl:"kms_key_id"`
 	AlicloudImageDeleteSSHPrivateKey  *bool                    `mapstructure:"image_delete_ssh_private_key" required:"false" cty:"image_delete_ssh_private_key" hcl:"image_delete_ssh_private_key"`
 	AssociatePublicIpAddress          *bool                    `mapstructure:"associate_public_ip_address" cty:"associate_public_ip_address" hcl:"associate_public_ip_address"`
 	ZoneId                            *string                  `mapstructure:"zone_id" required:"false" cty:"zone_id" hcl:"zone_id"`
@@ -223,8 +221,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_disk_mappings":              &hcldec.BlockListSpec{TypeName: "image_disk_mappings", Nested: hcldec.ObjectSpec((*FlatAlicloudDiskDevice)(nil).HCL2Spec())},
 		"target_image_family":              &hcldec.AttrSpec{Name: "target_image_family", Type: cty.String, Required: false},
 		"boot_mode":                        &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
-		"kms_key_copy_ids":                 &hcldec.AttrSpec{Name: "kms_key_copy_ids", Type: cty.List(cty.String), Required: false},
-		"kms_key_id":                       &hcldec.AttrSpec{Name: "kms_key_id", Type: cty.String, Required: false},
 		"image_delete_ssh_private_key":     &hcldec.AttrSpec{Name: "image_delete_ssh_private_key", Type: cty.Bool, Required: false},
 		"associate_public_ip_address":      &hcldec.AttrSpec{Name: "associate_public_ip_address", Type: cty.Bool, Required: false},
 		"zone_id":                          &hcldec.AttrSpec{Name: "zone_id", Type: cty.String, Required: false},

--- a/builder/ecs/image_config.go
+++ b/builder/ecs/image_config.go
@@ -168,10 +168,6 @@ type AlicloudImageConfig struct {
 	AlicloudTargetImageFamily string `mapstructure:"target_image_family" required:"false"`
 	// The boot mode of the user-defined image, it should to be one of 'BIOS', 'UEFI' or 'UEFI-Preferred'.
 	AlicloudBootMode string `mapstructure:"boot_mode" required:"false"`
-	// Copy to the destination KMS key ID array
-	AlicloudKMSKeyCopyIds []string `mapstructure:"kms_key_copy_ids" required:"false"`
-	// The source image KMS key ID used to encrypt the disk.
-	AlicloudKMSKeyId string `mapstructure:"kms_key_id" required:"false"`
 	// If set to true, the ECS keypair information will be removed. The default value is false.
 	AlicloudImageDeleteSSHPrivateKey bool `mapstructure:"image_delete_ssh_private_key" required:"false"`
 }

--- a/builder/ecs/step_create_instance.go
+++ b/builder/ecs/step_create_instance.go
@@ -50,14 +50,14 @@ func (s *stepCreateAlicloudInstance) Run(ctx context.Context, state multistep.St
 	ui := state.Get("ui").(packersdk.Ui)
 
 	ui.Say("Creating instance...")
-	runInstanceRequest, err := s.buildCreateInstanceRequest(state)
+	createInstanceRequest, err := s.buildCreateInstanceRequest(state)
 	if err != nil {
 		return halt(state, err, "")
 	}
 
-	runInstancesResponse, err := client.WaitForExpected(&WaitForExpectArgs{
+	createInstanceResponse, err := client.WaitForExpected(&WaitForExpectArgs{
 		RequestFunc: func() (responses.AcsResponse, error) {
-			return client.RunInstances(runInstanceRequest)
+			return client.CreateInstance(createInstanceRequest)
 		},
 		EvalFunc: client.EvalCouldRetryResponse(createInstanceRetryErrors, EvalRetryErrorType),
 	})
@@ -66,9 +66,9 @@ func (s *stepCreateAlicloudInstance) Run(ctx context.Context, state multistep.St
 		return halt(state, err, "Error creating instance")
 	}
 
-	instanceId := runInstancesResponse.(*ecs.RunInstancesResponse).InstanceIdSets.InstanceIdSet[0]
+	instanceId := createInstanceResponse.(*ecs.CreateInstanceResponse).InstanceId
 
-	_, err = client.WaitForInstanceStatus(s.RegionId, instanceId, InstanceStatusRunning)
+	_, err = client.WaitForInstanceStatus(s.RegionId, instanceId, InstanceStatusStopped)
 	if err != nil {
 		return halt(state, err, "Error waiting create instance")
 	}
@@ -78,21 +78,6 @@ func (s *stepCreateAlicloudInstance) Run(ctx context.Context, state multistep.St
 	instances, err := client.DescribeInstances(describeInstancesRequest)
 	if err != nil {
 		return halt(state, err, "")
-	}
-	status := instances.Instances.Instance[0].Status
-	if status == InstanceStatusRunning {
-		stopInstanceRequest := ecs.CreateStopInstanceRequest()
-		stopInstanceRequest.InstanceId = instanceId
-		if _, err := client.StopInstance(stopInstanceRequest); err != nil {
-			return halt(state, err, "Error stopping instance")
-		}
-
-		ui.Say(fmt.Sprintf("Stoping instance: %s", instanceId))
-
-		_, err = client.WaitForInstanceStatus(s.RegionId, instanceId, InstanceStatusStopped)
-		if err != nil {
-			return halt(state, err, "Timeout waiting for instance to stop")
-		}
 	}
 
 	ui.Message(fmt.Sprintf("Created instance: %s", instanceId))
@@ -130,8 +115,8 @@ func (s *stepCreateAlicloudInstance) Cleanup(state multistep.StateBag) {
 	}
 }
 
-func (s *stepCreateAlicloudInstance) buildCreateInstanceRequest(state multistep.StateBag) (*ecs.RunInstancesRequest, error) {
-	request := ecs.CreateRunInstancesRequest()
+func (s *stepCreateAlicloudInstance) buildCreateInstanceRequest(state multistep.StateBag) (*ecs.CreateInstanceRequest, error) {
+	request := ecs.CreateCreateInstanceRequest()
 	request.ClientToken = uuid.TimeOrderedUUID()
 	request.RegionId = s.RegionId
 	request.InstanceType = s.InstanceType
@@ -188,19 +173,13 @@ func (s *stepCreateAlicloudInstance) buildCreateInstanceRequest(state multistep.
 	systemDisk := config.AlicloudImageConfig.ECSSystemDiskMapping
 	request.SystemDiskDiskName = systemDisk.DiskName
 	request.SystemDiskCategory = systemDisk.DiskCategory
-	request.SystemDiskSize = strconv.Itoa(systemDisk.DiskSize)
+	request.SystemDiskSize = requests.Integer(convertNumber(systemDisk.DiskSize))
 	request.SystemDiskDescription = systemDisk.Description
 
-	var runInstancesSystemDisk ecs.RunInstancesSystemDisk
-	if systemDisk.Encrypted != confighelper.TriUnset {
-		runInstancesSystemDisk.Encrypted = strconv.FormatBool(systemDisk.Encrypted.True())
-	}
-	request.SystemDisk = runInstancesSystemDisk
-
 	imageDisks := config.AlicloudImageConfig.ECSImagesDiskMappings
-	var dataDisks []ecs.RunInstancesDataDisk
+	var dataDisks []ecs.CreateInstanceDataDisk
 	for _, imageDisk := range imageDisks {
-		var dataDisk ecs.RunInstancesDataDisk
+		var dataDisk ecs.CreateInstanceDataDisk
 		dataDisk.DiskName = imageDisk.DiskName
 		dataDisk.Category = imageDisk.DiskCategory
 		dataDisk.Size = convertNumber(imageDisk.DiskSize)
@@ -239,11 +218,11 @@ func (s *stepCreateAlicloudInstance) getUserData(state multistep.StateBag) (stri
 
 }
 
-func buildCreateInstanceTags(tags map[string]string) *[]ecs.RunInstancesTag {
-	var ecsTags []ecs.RunInstancesTag
+func buildCreateInstanceTags(tags map[string]string) *[]ecs.CreateInstanceTag {
+	var ecsTags []ecs.CreateInstanceTag
 
 	for k, v := range tags {
-		ecsTags = append(ecsTags, ecs.RunInstancesTag{Key: k, Value: v})
+		ecsTags = append(ecsTags, ecs.CreateInstanceTag{Key: k, Value: v})
 	}
 
 	return &ecsTags

--- a/builder/ecs/step_region_copy_image.go
+++ b/builder/ecs/step_region_copy_image.go
@@ -18,7 +18,6 @@ import (
 type stepRegionCopyAlicloudImage struct {
 	AlicloudImageDestinationRegions []string
 	AlicloudImageDestinationNames   []string
-	KmsKeyIds                       []string
 	RegionId                        string
 	WaitCopyingImageReadyTimeout    int
 }
@@ -29,7 +28,6 @@ func (s *stepRegionCopyAlicloudImage) Run(ctx context.Context, state multistep.S
 	if config.ImageEncrypted != confighelper.TriUnset {
 		s.AlicloudImageDestinationRegions = append(s.AlicloudImageDestinationRegions, s.RegionId)
 		s.AlicloudImageDestinationNames = append(s.AlicloudImageDestinationNames, config.AlicloudImageName)
-		s.KmsKeyIds = append(s.KmsKeyIds, config.AlicloudKMSKeyId)
 	}
 
 	if len(s.AlicloudImageDestinationRegions) == 0 {
@@ -50,10 +48,8 @@ func (s *stepRegionCopyAlicloudImage) Run(ctx context.Context, state multistep.S
 		}
 
 		ecsImageName := ""
-		kmsKeyId := ""
 		if numberOfName > 0 && index < numberOfName {
 			ecsImageName = s.AlicloudImageDestinationNames[index]
-			kmsKeyId = s.KmsKeyIds[index]
 		}
 
 		copyImageRequest := ecs.CreateCopyImageRequest()
@@ -63,7 +59,6 @@ func (s *stepRegionCopyAlicloudImage) Run(ctx context.Context, state multistep.S
 		copyImageRequest.DestinationImageName = ecsImageName
 		copyImageRequest.ResourceGroupId = config.AlicloudResourceGroupId
 		if config.ImageEncrypted != confighelper.TriUnset {
-			copyImageRequest.KMSKeyId = kmsKeyId
 			copyImageRequest.Encrypted = requests.NewBoolean(config.ImageEncrypted.True())
 		}
 

--- a/docs-partials/builder/ecs/AlicloudImageConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/AlicloudImageConfig-not-required.mdx
@@ -65,10 +65,6 @@
 
 - `boot_mode` (string) - The boot mode of the user-defined image, it should to be one of 'BIOS', 'UEFI' or 'UEFI-Preferred'.
 
-- `kms_key_copy_ids` ([]string) - Copy to the destination KMS key ID array
-
-- `kms_key_id` (string) - The source image KMS key ID used to encrypt the disk.
-
 - `image_delete_ssh_private_key` (bool) - If set to true, the ECS keypair information will be removed. The default value is false.
 
 <!-- End of code generated from the comments of the AlicloudImageConfig struct in builder/ecs/image_config.go; -->

--- a/post-processor/alicloud-import/post-processor.hcl2spec.go
+++ b/post-processor/alicloud-import/post-processor.hcl2spec.go
@@ -52,8 +52,6 @@ type FlatConfig struct {
 	ECSImagesDiskMappings             []ecs.FlatAlicloudDiskDevice `mapstructure:"image_disk_mappings" required:"false" cty:"image_disk_mappings" hcl:"image_disk_mappings"`
 	AlicloudTargetImageFamily         *string                      `mapstructure:"target_image_family" required:"false" cty:"target_image_family" hcl:"target_image_family"`
 	AlicloudBootMode                  *string                      `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
-	AlicloudKMSKeyCopyIds             []string                     `mapstructure:"kms_key_copy_ids" required:"false" cty:"kms_key_copy_ids" hcl:"kms_key_copy_ids"`
-	AlicloudKMSKeyId                  *string                      `mapstructure:"kms_key_id" required:"false" cty:"kms_key_id" hcl:"kms_key_id"`
 	AlicloudImageDeleteSSHPrivateKey  *bool                        `mapstructure:"image_delete_ssh_private_key" required:"false" cty:"image_delete_ssh_private_key" hcl:"image_delete_ssh_private_key"`
 	AssociatePublicIpAddress          *bool                        `mapstructure:"associate_public_ip_address" cty:"associate_public_ip_address" hcl:"associate_public_ip_address"`
 	ZoneId                            *string                      `mapstructure:"zone_id" required:"false" cty:"zone_id" hcl:"zone_id"`
@@ -195,8 +193,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_disk_mappings":              &hcldec.BlockListSpec{TypeName: "image_disk_mappings", Nested: hcldec.ObjectSpec((*ecs.FlatAlicloudDiskDevice)(nil).HCL2Spec())},
 		"target_image_family":              &hcldec.AttrSpec{Name: "target_image_family", Type: cty.String, Required: false},
 		"boot_mode":                        &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
-		"kms_key_copy_ids":                 &hcldec.AttrSpec{Name: "kms_key_copy_ids", Type: cty.List(cty.String), Required: false},
-		"kms_key_id":                       &hcldec.AttrSpec{Name: "kms_key_id", Type: cty.String, Required: false},
 		"image_delete_ssh_private_key":     &hcldec.AttrSpec{Name: "image_delete_ssh_private_key", Type: cty.Bool, Required: false},
 		"associate_public_ip_address":      &hcldec.AttrSpec{Name: "associate_public_ip_address", Type: cty.Bool, Required: false},
 		"zone_id":                          &hcldec.AttrSpec{Name: "zone_id", Type: cty.String, Required: false},


### PR DESCRIPTION
refactor: replace RunInstances API with CreateInstance API for ECS，
The previous change from RunInstances to CreateInstance may cause the instance to be stopped before image initialization is complete, which poses a significant risk. This is very urgent.
Please review and merge the code